### PR TITLE
Working diagnostics

### DIFF
--- a/src/Lean/Data/JsonRpc.lean
+++ b/src/Lean/Data/JsonRpc.lean
@@ -13,9 +13,56 @@ inductive RequestID
 | num (n : JsonNumber)
 | null
 
+-- TODO maybe put this in Json ns?
 inductive Structured
 | arr (elems : Array Json)
 | obj (kvPairs : RBNode String (fun _ => Json))
+
+/-- Error codes defined by JSON-RPC and LSP. -/
+inductive ErrorCode
+| parseError
+| invalidRequest
+| methodNotFound
+| invalidParams
+| internalError
+| serverErrorStart
+| serverErrorEnd
+| serverNotInitialized
+| unknownErrorCode
+-- LSP-specific codes below.
+| requestCancelled
+| contentModified
+
+instance hasFromJsonErrorCode : HasFromJson ErrorCode :=
+⟨fun j => match j with
+  | num n =>
+    if      n = (-32700 : Int) then ErrorCode.parseError
+    else if n = (-32600 : Int) then ErrorCode.invalidRequest
+    else if n = (-32601 : Int) then ErrorCode.methodNotFound
+    else if n = (-32602 : Int) then ErrorCode.invalidParams
+    else if n = (-32603 : Int) then ErrorCode.internalError
+    else if n = (-32099 : Int) then ErrorCode.serverErrorStart
+    else if n = (-32000 : Int) then ErrorCode.serverErrorEnd
+    else if n = (-32002 : Int) then ErrorCode.serverNotInitialized
+    else if n = (-32001 : Int) then ErrorCode.unknownErrorCode
+    else if n = (-32800 : Int) then ErrorCode.requestCancelled
+    else if n = (-32801 : Int) then ErrorCode.contentModified
+    else none
+  | _ => none⟩
+
+instance hasToJsonErrorCode : HasToJson ErrorCode :=
+⟨fun e => match e with
+  | ErrorCode.parseError           => (-32700 : Int)
+  | ErrorCode.invalidRequest       => (-32600 : Int)
+  | ErrorCode.methodNotFound       => (-32601 : Int)
+  | ErrorCode.invalidParams        => (-32602 : Int)
+  | ErrorCode.internalError        => (-32603 : Int)
+  | ErrorCode.serverErrorStart     => (-32099 : Int)
+  | ErrorCode.serverErrorEnd       => (-32000 : Int)
+  | ErrorCode.serverNotInitialized => (-32002 : Int)
+  | ErrorCode.unknownErrorCode     => (-32001 : Int)
+  | ErrorCode.requestCancelled     => (-32800 : Int)
+  | ErrorCode.contentModified      => (-32801 : Int)⟩
 
 -- uses Option Structured because users will likely rarely distinguish between an empty
 -- parameter array and an omitted params field.
@@ -25,7 +72,7 @@ inductive Message
 | request (id : RequestID) (method : String) (params? : Option Structured)
 | requestNotification (method : String) (params? : Option Structured)
 | response (id : RequestID) (result : Json)
-| responseError (id : RequestID) (code : JsonNumber) (message : String) (data? : Option Json)
+| responseError (id : RequestID) (code : ErrorCode) (message : String) (data? : Option Json)
 
 def Batch := Array Message
 
@@ -45,8 +92,9 @@ instance requestIDToJson : HasToJson RequestID :=
   | RequestID.str s => s
   | RequestID.num n => num n
   | RequestID.null  => null⟩
+
 instance requestIDFromJson : HasFromJson RequestID :=
-⟨fun j => match j with 
+⟨fun j => match j with
   | str s => RequestID.str s
   | num n => RequestID.num n
   | _     => none⟩
@@ -55,6 +103,7 @@ instance structuredToJson : HasToJson Structured :=
 ⟨fun s => match s with
   | Structured.arr a => arr a
   | Structured.obj o => obj o⟩
+
 instance structuredFromJson : HasFromJson Structured :=
 ⟨fun j => match j with
   | arr a => Structured.arr a
@@ -62,7 +111,7 @@ instance structuredFromJson : HasFromJson Structured :=
   | _     => none⟩
 
 instance messageToJson : HasToJson Message :=
-⟨fun m =>   
+⟨fun m =>
   mkObj $ ⟨"jsonrpc", "2.0"⟩ :: match m with
   | Message.request id method params? =>
     [⟨"id", toJson id⟩, ⟨"method", method⟩] ++ opt "params" params?
@@ -71,8 +120,8 @@ instance messageToJson : HasToJson Message :=
   | Message.response id result =>
     [⟨"id", toJson id⟩, ⟨"result", result⟩]
   | Message.responseError id code message data? =>
-    [⟨"id", toJson id⟩, 
-     ⟨"error", mkObj $ 
+    [⟨"id", toJson id⟩,
+     ⟨"error", mkObj $
        [⟨"code", toJson code⟩, ⟨"message", message⟩] ++ opt "data" data?⟩]⟩
 
 def aux1 (j : Json) : Option Message := do
@@ -94,7 +143,7 @@ pure (Message.response id result)
 def aux4 (j : Json) : Option Message := do
 id ← j.getObjValAs? RequestID "id";
 err ← j.getObjVal? "error";
-code ← err.getObjValAs? JsonNumber "code";
+code ← err.getObjValAs? ErrorCode "code";
 message ← err.getObjValAs? String "message";
 let data? := err.getObjVal? "data";
 pure (Message.responseError id code message data?)
@@ -124,7 +173,7 @@ match m with
 | Message.request id method params? =>
   if method = expectedMethod then
     match params? with
-    | some params => 
+    | some params =>
       let j := toJson params;
       match fromJson? j with
       | some v => pure ⟨id, v⟩
@@ -140,7 +189,7 @@ match m with
 | Message.requestNotification method params? =>
   if method = expectedMethod then
     match params? with
-    | some params => 
+    | some params =>
       let j := toJson params;
       match fromJson? j with
       | some v => pure v

--- a/src/Lean/Data/Lsp/Capabilities.lean
+++ b/src/Lean/Data/Lsp/Capabilities.lean
@@ -8,21 +8,23 @@ open Lean
 open Lean.Json
 open Lean.JsonRpc
 
--- TODO: right now we ignore the capabilities
+-- TODO: right now we ignore the client's capabilities
 inductive ClientCapabilities | mk
-
--- largely unimplemented
-structure ServerCapabilities :=
-(textDocumentSync? : Option TextDocumentSyncOptions := none)
-
-def mkLeanServerCapabilities : ServerCapabilities :=
-{textDocumentSync? := some {openClose := true, change? := TextDocumentSyncKind.incremental}}
 
 instance clientCapabilitiesHasFromJson : HasFromJson ClientCapabilities :=
 ⟨fun j => ClientCapabilities.mk⟩
 
+-- TODO largely unimplemented
+structure ServerCapabilities :=
+(textDocumentSync? : Option TextDocumentSyncOptions := none)
+
 instance serverCapabilitiesHasToJson : HasToJson ServerCapabilities :=
 ⟨fun o => mkObj $
   opt "textDocumentSync" o.textDocumentSync? ++ []⟩
+
+def mkLeanServerCapabilities : ServerCapabilities :=
+{ textDocumentSync? := some
+  { openClose := true
+  , change? := TextDocumentSyncKind.incremental }}
 
 end Lean.Lsp

--- a/src/Lean/Data/Lsp/Communication.lean
+++ b/src/Lean/Data/Lsp/Communication.lean
@@ -30,8 +30,9 @@ private partial def readHeaderFields : FS.Handle → IO (List (String × String)
     | some hf => do
       tail ← readHeaderFields h;
       pure (hf :: tail)
-    | none => throw (userError "invalid header field")
-    
+    | none => throw (userError $ "invalid header field" ++ l)
+
+-- Returns the Content-Length.
 private def readLspHeader (h : FS.Handle) : IO Nat := do
 fields ← readHeaderFields h;
 match fields.lookup "Content-Length" with
@@ -58,9 +59,9 @@ def writeLspMessage (h : FS.Handle) (m : Message) : IO Unit := do
 let j := (toJson m).compress;
 let header := "Content-Length: " ++ toString j.utf8ByteSize ++ "\r\n\r\n";
 h.putStr (header ++ j);
-IO.println "starting to flush now";
-h.flush;
-IO.println "flushed"
+--IO.println "starting to flush now";
+h.flush
+--IO.println "flushed";
 
 def writeLspResponse {α : Type*} [Lean.HasToJson α] (h : FS.Handle) (id : RequestID) (r : α) : IO Unit :=
 writeLspMessage h (Message.response id (toJson r))

--- a/src/Lean/Data/Lsp/GeneralMessage.lean
+++ b/src/Lean/Data/Lsp/GeneralMessage.lean
@@ -7,34 +7,9 @@ namespace Lean.Lsp
 open Lean
 open Lean.Json
 
-structure ClientInfo := (name : String) (version? : Option String := none)
-
-inductive Trace
-| messages
-| verbose
-
-structure InitializeParams :=
--- id of parent process, none if no parent process
-(processId? : Option Int := none)
-(clientInfo? : Option ClientInfo := none)
--- we don't support the deprecated rootPath
--- none: no folder is open
-(rootUri? : Option String := none) 
-(initializationOptions? : Option Json := none)
-(capabilities : ClientCapabilities)
-(trace? : Option Trace := none) -- none: no trace
---(workspaceFolders? : Option Unit) TODO
-
-inductive Initialized
-| mk
-
-structure ServerInfo :=
+structure ClientInfo :=
 (name : String)
 (version? : Option String := none)
-
-structure InitializeResult :=
-(capabilities : ServerCapabilities)
-(serverInfo? : Option String := none)
 
 instance clientInfoHasFromJson : HasFromJson ClientInfo :=
 ⟨fun j => do
@@ -42,11 +17,28 @@ instance clientInfoHasFromJson : HasFromJson ClientInfo :=
   let version? := j.getObjValAs? String "version";
   pure ⟨name, version?⟩⟩
 
+inductive Trace
+| messages
+| verbose
+
 instance traceHasFromJson : HasFromJson Trace :=
 ⟨fun j => match j.getStr? with
-  | some "messages" => Trace.messages
-  | some "verbose" => Trace.verbose
-  | _ => none⟩
+| some "messages" => Trace.messages
+| some "verbose" => Trace.verbose
+| _ => none⟩
+
+structure InitializeParams :=
+-- id of parent process, none if no parent process
+(processId? : Option Int := none)
+(clientInfo? : Option ClientInfo := none)
+/- We don't support the deprecated rootPath
+(rootPath? : Option String)-/
+-- none: no folder is open
+(rootUri? : Option String := none)
+(initializationOptions? : Option Json := none)
+(capabilities : ClientCapabilities)
+(trace? : Option Trace := none) -- none: no trace
+--(workspaceFolders? : Option Unit) TODO
 
 instance initializeParamsHasFromJson : HasFromJson InitializeParams :=
 ⟨fun j => do
@@ -65,15 +57,26 @@ instance initializeParamsHasFromJson : HasFromJson InitializeParams :=
   let trace? := j.getObjValAs? Trace "trace";
   pure ⟨processId?, clientInfo?, rootUri?, initializationOptions?, capabilities, trace?⟩⟩
 
+inductive Initialized
+| mk
+
 instance initializedHasFromJson : HasFromJson Initialized :=
 ⟨fun j => Initialized.mk⟩
 
+structure ServerInfo :=
+(name : String)
+(version? : Option String := none)
+
 instance serverInfoHasToJson : HasToJson ServerInfo :=
 ⟨fun o => mkObj $
-  ⟨"name", o.name⟩ :: opt "version" o.version? ++ []⟩
+  ⟨"name", o.name⟩ :: opt "version" o.version?⟩
+
+structure InitializeResult :=
+(capabilities : ServerCapabilities)
+(serverInfo? : Option ServerInfo := none)
 
 instance initializeResultHasToJson : HasToJson InitializeResult :=
 ⟨fun o => mkObj $
-  ⟨"capabilities", toJson o.capabilities⟩ :: opt "serverInfo" o.serverInfo? ++ []⟩
+  ⟨"capabilities", toJson o.capabilities⟩ :: opt "serverInfo" o.serverInfo?⟩
 
 end Lean.Lsp

--- a/src/Lean/Data/Lsp/Structure.lean
+++ b/src/Lean/Data/Lsp/Structure.lean
@@ -19,7 +19,7 @@ structure Range := (start : Position) («end» : Position)
 
 structure Location := (uri : DocumentUri) (range : Range)
 
-structure LocationLink := 
+structure LocationLink :=
 -- span in origin that is highlighted (e.g. underlined).
 -- default for none: word range at mouse position
 (originSelectionRange? : Option Range)
@@ -30,29 +30,69 @@ structure LocationLink :=
 -- must be a subrange of targetRange
 (targetSelectionRange : Range)
 
-inductive DiagnosticSeverity 
+inductive DiagnosticSeverity
 | error | warning | information | hint
 
-inductive DiagnosticCode 
-| int (i : Int) 
-| string (s : String) 
+instance diagnosticSeverityHasFromJson : HasFromJson DiagnosticSeverity :=
+⟨fun j => match j.getNat? with
+  | some 1 => DiagnosticSeverity.error
+  | some 2 => DiagnosticSeverity.warning
+  | some 3 => DiagnosticSeverity.information
+  | some 4 => DiagnosticSeverity.hint
+  | _      => none⟩
 
-inductive DiagnosticTag 
--- faded out in client
+instance diagnosticSeverityHasToJson : HasToJson DiagnosticSeverity :=
+⟨fun o => match o with
+  | DiagnosticSeverity.error       => (1 : Nat)
+  | DiagnosticSeverity.warning     => (2 : Nat)
+  | DiagnosticSeverity.information => (3 : Nat)
+  | DiagnosticSeverity.hint        => (4 : Nat)⟩
+
+inductive DiagnosticCode
+| int (i : Int)
+| string (s : String)
+
+instance diagnosticCodeHasToJson : HasToJson DiagnosticCode :=
+⟨fun o => match o with
+  | DiagnosticCode.int i    => i
+  | DiagnosticCode.string s => s⟩
+
+inductive DiagnosticTag
+/- Unused or unnecessary code.
+
+Clients are allowed to render diagnostics with this tag faded out instead of having
+an error squiggle. -/
 | unnecessary
--- struck through in client
+/- Deprecated or obsolete code.
+
+Clients are allowed to rendered diagnostics with this tag strike through. -/
 | deprecated
 
-structure DiagnosticRelatedInformation := (location : Location) (message : String)
+/- Represents a related message and source code location for a diagnostic. This should be
+used to point to code locations that cause or are related to a diagnostics, e.g when duplicating
+a symbol in a scope. -/
+structure DiagnosticRelatedInformation :=
+(location : Location)
+(message : String)
 
 structure Diagnostic :=
+/- The range at which the message applies. -/
 (range : Range)
--- none: client is free to choose severity
+/- The diagnostic's severity. Can be omitted. If omitted it is up to the
+client to interpret diagnostics as error, warning, info or hint. -/
 (severity? : Option DiagnosticSeverity := none)
+/- The diagnostic's code, which might appear in the user interface. -/
 (code? : Option DiagnosticCode := none)
+/- A human-readable string describing the source of this
+diagnostic, e.g. 'typescript' or 'super lint'. -/
 (source? : Option String := none)
+/- The diagnostic's message. -/
 (message : String)
+/- Additional metadata about the diagnostic.
+@since 3.15.0 -/
 (tags? : Option (Array DiagnosticTag) := none)
+/- An array of related diagnostic information, e.g. when symbol-names within
+a scope collide all definitions can be marked via this property. -/
 (relatedInformation? : Option (Array DiagnosticRelatedInformation) := none)
 
 structure Command :=
@@ -64,11 +104,11 @@ structure Command :=
 
 structure TextEdit :=
 -- text insertion: start = end
-(range : Range) 
+(range : Range)
 -- text deletion: empty string
 (newText : String)
 
--- no intermediate states: 
+-- no intermediate states:
 -- - ranges may not overlap
 -- - multiple inserts can have the same starting position
 -- - the order of the array induces the insert order
@@ -78,7 +118,7 @@ def TextEditBatch := Array TextEdit
 
 structure TextDocumentIdentifier := (uri : DocumentUri)
 
-structure VersionedTextDocumentIdentifier := 
+structure VersionedTextDocumentIdentifier :=
 (uri : DocumentUri)
 -- increases after each change, undo and redo
 -- none used when a document is not open and the
@@ -89,7 +129,7 @@ structure TextDocumentEdit :=
 (textDocument : VersionedTextDocumentIdentifier)
 (edits : TextEditBatch)
 
--- TODO(Marc): missing: 
+-- TODO(Marc): missing:
 -- File Resource Changes, WorkspaceEdit
 -- both of these are pretty global, we can look at their
 -- uses when single file behaviour works.
@@ -104,11 +144,11 @@ structure TextDocumentItem :=
 (text : String)
 
 -- parameter literal for requests
-structure TextDocumentPositionParams := 
+structure TextDocumentPositionParams :=
 (textDocument : TextDocumentIdentifier)
 (position : Position)
 
-structure DocumentFilter := 
+structure DocumentFilter :=
 (language? : Option String := none) -- language id
 -- uri scheme like 'file' or 'untitled'
 (scheme? : Option String := none)
@@ -127,7 +167,7 @@ def DocumentSelector := Array DocumentFilter
 structure TextDocumentRegistrationOptions := (documentSelector? : Option DocumentSelector := none)
 
 -- TODO(Marc): missing:
--- StaticRegistrationOptions, 
+-- StaticRegistrationOptions,
 -- MarkupContent, WorkDoneProgressBegin, WorkDoneProgressReport,
 -- WorkDoneProgressEnd, WorkDoneProgressParams,
 -- WorkDoneProgressOptions, PartialResultParams
@@ -154,15 +194,6 @@ instance locationHasFromJson : HasFromJson Location :=
   uri ← j.getObjValAs? DocumentUri "uri";
   range ← j.getObjValAs? Range "range";
   pure ⟨uri, range⟩⟩
-
-
-instance diagnosticSeverityHasFromJson : HasFromJson DiagnosticSeverity :=
-⟨fun j => match j.getNat? with
-  | some 1 => DiagnosticSeverity.error
-  | some 2 => DiagnosticSeverity.warning
-  | some 3 => DiagnosticSeverity.information
-  | some 4 => DiagnosticSeverity.hint
-  | _      => none⟩
 
 instance diagnosticCodeHasFromJson : HasFromJson DiagnosticCode :=
 ⟨fun j => match j with
@@ -225,7 +256,6 @@ instance documentSelectorHasFromJson : HasFromJson DocumentSelector :=
 instance textDocumentRegistrationOptionsHasFromJson : HasFromJson TextDocumentRegistrationOptions :=
 ⟨fun j => some ⟨j.getObjValAs? DocumentSelector "documentSelector"⟩⟩
 
-
 instance documentUriHasToJson : HasToJson DocumentUri :=
 ⟨fun (o : String) => o⟩
 
@@ -235,23 +265,11 @@ instance positionHasToJson : HasToJson Position :=
 
 instance rangeHasToJson : HasToJson Range :=
 ⟨fun o => mkObj $
-  ⟨"start", toJson o.start⟩ :: ⟨"«end»", toJson o.«end»⟩ :: []⟩
+  ⟨"start", toJson o.start⟩ :: ⟨"end", toJson o.«end»⟩ :: []⟩
 
 instance locationHasToJson : HasToJson Location :=
 ⟨fun o => mkObj $
   ⟨"uri", toJson o.uri⟩ :: ⟨"range", toJson o.range⟩ :: []⟩
-
-instance diagnosticSeverityHasToJson : HasToJson DiagnosticSeverity :=
-⟨fun o => match o with
-  | DiagnosticSeverity.error       => (1 : Nat)
-  | DiagnosticSeverity.warning     => (2 : Nat)
-  | DiagnosticSeverity.information => (3 : Nat)
-  | DiagnosticSeverity.hint        => (4 : Nat)⟩
-
-instance diagnosticCodeHasToJson : HasToJson DiagnosticCode :=
-⟨fun o => match o with
-  | DiagnosticCode.int i    => i
-  | DiagnosticCode.string s => s⟩
 
 instance diagnosticTagHasToJson : HasToJson DiagnosticTag :=
 ⟨fun o => match o with
@@ -264,7 +282,7 @@ instance diagnosticRelatedInformationHasToJson : HasToJson DiagnosticRelatedInfo
 
 instance diagnosticHasToJson : HasToJson Diagnostic :=
 ⟨fun o => mkObj $
-  ⟨"range", toJson o.range⟩ :: opt "severity" o.severity? ++ opt "code" o.code? ++ 
+  ⟨"range", toJson o.range⟩ :: opt "severity" o.severity? ++ opt "code" o.code? ++
     opt "source" o.source? ++ ⟨"message", o.message⟩ :: opt "tags" o.tags? ++ []⟩
 
 end Lean.Lsp

--- a/src/Lean/Data/Lsp/TextSync.lean
+++ b/src/Lean/Data/Lsp/TextSync.lean
@@ -42,8 +42,21 @@ inductive TextDocumentContentChangeEvent
 | fullChange (text : String)
 
 structure DidChangeTextDocumentParams :=
--- version number points to version after all changes have been applied
+/- The document that did change. The version number points
+to the version after all provided content changes have
+been applied. -/
 (textDocument : VersionedTextDocumentIdentifier)
+/- The actual content changes. The content changes describe single state changes
+to the document. So if there are two content changes c1 (at array index 0) and
+c2 (at array index 1) for a document in state S then c1 moves the document from
+S to S' and c2 from S' to S''. So c1 is computed on the state S and c2 is computed
+on the state S'.
+
+To mirror the content of a document using change events use the following approach:
+- start with the same initial content
+- apply the 'textDocument/didChange' notifications in the order you recevie them.
+- apply the `TextDocumentContentChangeEvent`s in a single notification in the order
+  you receive them. -/
 (contentChanges : Array TextDocumentContentChangeEvent)
 
 -- TODO: missing:

--- a/src/Lean/Data/Lsp/TextSync.lean
+++ b/src/Lean/Data/Lsp/TextSync.lean
@@ -8,18 +8,29 @@ open Lean
 open Lean.Json
 
 inductive TextDocumentSyncKind
--- synced by sending full content and on every update
-| full 
--- synced by sending full content on open and otherwise
--- incremental updates
-| incremental 
+/- Documents should not be synced at all. -/
+--| none
+/- Documents are synced by always sending the full content of the document. -/
+| full
+/- Documents are synced by sending the full content on open. After that only incremental updates to the document are send. -/
+| incremental
 
 structure TextDocumentSyncOptions :=
-(openClose : Bool) -- open/close notifications are sent to server
-(change? : Option TextDocumentSyncKind := none) -- none: not synced
+/- Open and close notifications are sent to the server.
+If omitted open close notification should not be sent. -/
+(openClose : Bool)
+/- Change notifications are sent to the server.
+If omitted it defaults to TextDocumentSyncKind.None.
+none: not synced -/
+(change? : Option TextDocumentSyncKind := none)
 
 structure DidOpenTextDocumentParams :=
 (textDocument : TextDocumentItem)
+
+instance didOpenTextDocumentParamsHasFromJson : HasFromJson DidOpenTextDocumentParams :=
+⟨fun j => do
+  textDocument ← j.getObjValAs? TextDocumentItem "textDocument";
+  pure ⟨textDocument⟩⟩
 
 structure TextDocumentChangeRegistrationOptions :=
 (documentSelector? : Option DocumentSelector := none)
@@ -62,11 +73,6 @@ instance textDocumentSyncOptionsHasToJson : HasToJson TextDocumentSyncOptions :=
 ⟨fun o => mkObj $
   ⟨"openClose", o.openClose⟩ :: opt "change" o.change? ++ []⟩
 
-instance didOpenTextDocumentParamsHasFromJson : HasFromJson DidOpenTextDocumentParams :=
-⟨fun j => do
-  textDocument ← j.getObjValAs? TextDocumentItem "textDocument";
-  pure ⟨textDocument⟩⟩
-
 instance textDocumentChangeRegistrationOptionsHasFromJson : HasFromJson TextDocumentChangeRegistrationOptions :=
 ⟨fun j => do
   let documentSelector? := j.getObjValAs? DocumentSelector "documentSelector";
@@ -74,7 +80,7 @@ instance textDocumentChangeRegistrationOptionsHasFromJson : HasFromJson TextDocu
   pure ⟨documentSelector?, syncKind⟩⟩
 
 instance textDocumentContentChangeEventHasFromJson : HasFromJson TextDocumentContentChangeEvent :=
-⟨fun j => 
+⟨fun j =>
   (do
     range ← j.getObjValAs? Range "range";
     text ← j.getObjValAs? String "text";

--- a/src/Lean/Data/Lsp/Utf16.lean
+++ b/src/Lean/Data/Lsp/Utf16.lean
@@ -43,7 +43,7 @@ private def utf16ReplaceAux₀ : List Char → Nat → Nat → List Char
 private def utf16ReplaceAux₁ : List Char → List Char → Nat → Nat → List Char
 | [],     n :: new, i, endIdx => n :: new
 | s,      [],       i, endIdx => utf16ReplaceAux₀ s i endIdx
-| c :: s, n :: new, i, endIdx => 
+| c :: s, n :: new, i, endIdx =>
   if i ≥ endIdx then
     n :: new ++ c :: s -- range ended, insert rest of the text
   else
@@ -52,7 +52,7 @@ private def utf16ReplaceAux₁ : List Char → List Char → Nat → Nat → Lis
 private def utf16ReplaceAux₂ : List Char → List Char → Nat → Nat → Nat → List Char
 | [],     [],       i, startIdx, endIdx => []
 | [],     n :: new, i, startIdx, endIdx => n :: new
-| c :: s, new,      i, startIdx, endIdx => 
+| c :: s, new,      i, startIdx, endIdx =>
   if i ≥ startIdx then
     utf16ReplaceAux₁ (c :: s) new i endIdx
   else
@@ -66,7 +66,7 @@ end String
 namespace Array
 
 def insertAll {α} (as : Array α) (i : Nat) (as' : Array α) : Array α :=
-as'.reverse.foldr (fun a' acc => acc.insertAt i a') as
+as'.foldr (fun a' acc => acc.insertAt i a') as
 
 def eraseAll {α} (as : Array α) (i n : Nat) : Array α :=
 n.repeat (fun acc => acc.eraseIdx i) as
@@ -90,6 +90,6 @@ let endIdx := focused.iterateRev 0 $ fun lineIdx line endIdxAcc =>
 let focused := "\n".intercalate focused.toList;
 let replaced := (focused.utf16Replace newText si endIdx).splitOnEOLs.toArray;
 (text.eraseAll sl (el - sl + 1)).insertAll sl replaced
-    
+
 
 end Lean.Lsp

--- a/src/Lean/Elab/Frontend.lean
+++ b/src/Lean/Elab/Frontend.lean
@@ -112,7 +112,7 @@ match Parser.parseHeader env inputCtx with
   pure (cmdState.env, cmdState.messages)
 
 @[export lean_run_frontend]
-def runFrontentExport (env : Environment) (input : String) (fileName : String) (opts : Options) : IO (Option Environment) := do
+def runFrontendExport (env : Environment) (input : String) (fileName : String) (opts : Options) : IO (Option Environment) := do
 (env, messages) ← runFrontend env input opts (some fileName);
 messages.forM $ fun msg => IO.println msg;
 if messages.hasErrors then

--- a/src/Lean/Server/README.md
+++ b/src/Lean/Server/README.md
@@ -1,0 +1,23 @@
+## Logging LSP requests
+
+### In `bash`:
+
+```
+mkfifo pipe
+nc -l -p 12345 < pipe | tee client.log | ./build/bin/Server 2> stderr | tee pipe server.log
+```
+will create three files to follow with `tail -f` -- `client.log` for client messages, `server.log` for server messages and `stderr` for server `IO.stderr` debugging
+
+### In VSCode
+
+Set `$extension.trace.server` to `verbose` as described in the *Usage* section of [LSP Inspector](https://microsoft.github.io/language-server-protocol/inspector/).
+
+An easy way to get an LSP client is to build the [sample extension](https://github.com/Microsoft/vscode-extension-samples/tree/master/lsp-sample) and replace the server options in `extension.ts`:
+
+```typescript
+  let serverOptions: ServerOptions = {
+    command: "/usr/bin/nc",
+    args: ["localhost", "12345"],
+    options: null
+  };
+```

--- a/src/Lean/Server/Server.lean
+++ b/src/Lean/Server/Server.lean
@@ -39,7 +39,7 @@ match Parser.parseHeader envNul inputCtx with
 | (header, parserState, messages) => do
   (env, messages) ← processHeader header messages inputCtx;
   parserStateRef ← IO.mkRef parserState;
-  cmdStateRef    ← IO.mkRef $ Command.mkState env messages {};
+  cmdStateRef ← IO.mkRef $ Command.mkState env messages {};
   IO.processCommands inputCtx parserStateRef cmdStateRef;
   cmdState ← cmdStateRef.get;
   pure (env, cmdState.env, cmdState.messages)
@@ -53,9 +53,13 @@ cmdState ← cmdStateRef.get;
 pure (cmdState.env, cmdState.messages)
 
 def msgToDiagnostic (text : DocumentText) (m : Lean.Message) : Diagnostic :=
-let low : Lsp.Position := ⟨m.pos.line, (text.get! m.pos.line).codepointPosToUtf16Pos m.pos.column⟩;
+-- Lean Message line numbers are 1-based while LSP Positions are 0-based.
+let lowLn := m.pos.line - 1;
+let low : Lsp.Position := ⟨lowLn, (text.get! lowLn).codepointPosToUtf16Pos m.pos.column⟩;
 let high : Lsp.Position := match m.endPos with
-| some endPos => ⟨endPos.line, (text.get! endPos.line).codepointPosToUtf16Pos endPos.column⟩
+| some endPos =>
+  let highLn := endPos.line - 1;
+  ⟨highLn, (text.get! highLn).codepointPosToUtf16Pos endPos.column⟩
 | none        => low;
 let range : Range := ⟨low, high⟩;
 let severity := match m.severity with
@@ -144,7 +148,7 @@ def initialize (i o : FS.Handle) : IO Unit := do
 -- ignore InitializeParams for MWE
 r ← readLspRequestAs i "initialize" InitializeParams;
 writeLspResponse o r.id ({ capabilities := mkLeanServerCapabilities
-                          , serverInfo? := some { name := "Lean 4 server"
+                         , serverInfo? := some { name := "Lean 4 server"
                                                 , version? := "0.0.1" }} : InitializeResult);
 _ ← readLspRequestNotificationAs i "initialized" Initialized;
 openDocumentsRef ← IO.mkRef (RBMap.empty : DocumentMap);

--- a/src/Lean/Server/Server.lean
+++ b/src/Lean/Server/Server.lean
@@ -16,7 +16,10 @@ open Lean.Elab
 -- LSP indexes text with rows and colums
 abbrev DocumentText := Array String
 
-structure Document := (version : Int) (text : DocumentText) (headerEnv : Environment)
+structure Document :=
+(version : Int)
+(text : DocumentText)
+(headerEnv : Environment)
 
 abbrev DocumentMap := RBMap DocumentUri Document (fun a b => Decidable.decide (a < b))
 
@@ -31,7 +34,8 @@ match @fromJson? paramType _ params with
 
 def runFrontend (text : String) : IO (Environment × Environment × MessageLog) := do
 let inputCtx := Parser.mkInputContext text "<input>";
-match Parser.parseHeader {const2ModIdx := {}, constants := {}, extensions := #[]} inputCtx with
+envNul ← mkEmptyEnvironment;
+match Parser.parseHeader envNul inputCtx with
 | (header, parserState, messages) => do
   (env, messages) ← processHeader header messages inputCtx;
   parserStateRef ← IO.mkRef parserState;
@@ -60,7 +64,10 @@ let severity := match m.severity with
 | MessageSeverity.error       => DiagnosticSeverity.error;
 let source := "Lean 4 server";
 let message := toString (format m.data);
-{range := range, severity? := severity, source? := source, message := message}
+{ range := range
+, severity? := severity
+, source? := source
+, message := message}
 
 namespace ServerState
 
@@ -73,48 +80,59 @@ match openDocuments.find? key with
 def updateOpenDocuments (s : ServerState) (key : DocumentUri) (val : Document) : IO Unit :=
 s.openDocumentsRef.modify (fun documents => (documents.erase key).insert key val)
 
-def sendDiagnostics (s : ServerState) (uri : DocumentUri) (d : Document) (log : MessageLog) : IO Unit := 
+def sendDiagnostics (s : ServerState) (uri : DocumentUri) (d : Document) (log : MessageLog) : IO Unit :=
 let diagnostics := log.msgs.map (msgToDiagnostic d.text);
-writeLspNotification s.o "textDocument/publishDiagnostics" {uri := uri, version? := d.version, diagnostics := diagnostics.toArray : PublishDiagnosticsParams}
+writeLspNotification s.o "textDocument/publishDiagnostics"
+  { uri := uri
+  , version? := d.version
+  , diagnostics := diagnostics.toArray : PublishDiagnosticsParams }
 
 def handleDidOpen (s : ServerState) (p : DidOpenTextDocumentParams) : IO Unit := do
-let d := p.textDocument;
-let text := d.text.splitOnEOLs;
+let doc := p.textDocument;
+let text := doc.text.splitOnEOLs;
 (headerEnv, env, msgLog) ← runFrontend ("\n".intercalate text);
-let newDoc : Document := ⟨d.version, text.toArray, headerEnv⟩;
-s.openDocumentsRef.modify (fun openDocuments => openDocuments.insert d.uri newDoc);
-s.sendDiagnostics d.uri newDoc msgLog
+let newDoc : Document := ⟨doc.version, text.toArray, headerEnv⟩;
+s.openDocumentsRef.modify (fun openDocuments => openDocuments.insert doc.uri newDoc);
+s.sendDiagnostics doc.uri newDoc msgLog
 
 def handleDidChange (s : ServerState) (p : DidChangeTextDocumentParams) : IO Unit := do
-let d := p.textDocument;
-let c := p.contentChanges;
-oldDoc ← s.findOpenDocument d.uri;
-some newVersion ← pure d.version? | throw (userError "expected version number");
+let doc := p.textDocument;
+let changes := p.contentChanges;
+oldDoc ← s.findOpenDocument doc.uri;
+some newVersion ← pure doc.version? | throw (userError "expected version number");
 if newVersion <= oldDoc.version then do
   throw (userError "got outdated version number")
-else c.forM $ fun change =>
+else changes.forM $ fun change =>
   match change with
   | TextDocumentContentChangeEvent.rangeChange (range : Range) (newText : String) => do
     let newDocText := replaceRange oldDoc.text range newText;
     (newEnv, msgLog) ← updateFrontend oldDoc.headerEnv ("\n".intercalate newDocText.toList);
     let newDoc : Document := ⟨newVersion, newDocText, oldDoc.headerEnv⟩;
-    s.updateOpenDocuments d.uri newDoc;
-    s.sendDiagnostics d.uri newDoc msgLog
-  | TextDocumentContentChangeEvent.fullChange (text : String) => throw (userError "got content change that replaces the full document (not supported)") 
+    s.updateOpenDocuments doc.uri newDoc;
+    s.sendDiagnostics doc.uri newDoc msgLog
+  | TextDocumentContentChangeEvent.fullChange (text : String) =>
+    throw (userError "got content change that replaces the full document (not supported)")
 
 def handleNotification (s : ServerState) (method : String) (params : Json) : IO Unit := do
-let h := (fun paramType [HasFromJson paramType] (handler : ServerState → paramType → IO Unit) => 
+let h := (fun paramType [HasFromJson paramType] (handler : ServerState → paramType → IO Unit) =>
   parseParams paramType params >>= handler s);
 match method with
 | "textDocument/didOpen"   => h DidOpenTextDocumentParams handleDidOpen
 | "textDocument/didChange" => h DidChangeTextDocumentParams handleDidChange
 | _                        => throw (userError "got unsupported notification method")
 
+def handleRequest (s : ServerState) (id : RequestID) (method : String) (params : Json)
+  : IO Unit := do
+  match method with
+  | _ => throw (userError "Not supporting requests for now!")
+
 partial def mainLoop : ServerState → IO Unit
 | s => do
   m ← readLspMessage s.i;
   match m with
-  | Message.request id method (some params) => pure ()
+  | Message.request id method (some params) => do
+    s.handleRequest id method (toJson params);
+    mainLoop s
   | Message.requestNotification method (some params) => do
     s.handleNotification method (toJson params);
     mainLoop s
@@ -125,7 +143,9 @@ end ServerState
 def initialize (i o : FS.Handle) : IO Unit := do
 -- ignore InitializeParams for MWE
 r ← readLspRequestAs i "initialize" InitializeParams;
-writeLspResponse o r.id mkLeanServerCapabilities;
+writeLspResponse o r.id ({ capabilities := mkLeanServerCapabilities
+                          , serverInfo? := some { name := "Lean 4 server"
+                                                , version? := "0.0.1" }} : InitializeResult);
 _ ← readLspRequestNotificationAs i "initialized" Initialized;
 openDocumentsRef ← IO.mkRef (RBMap.empty : DocumentMap);
 ServerState.mainLoop ⟨i, o, openDocumentsRef⟩

--- a/src/Lean/Server/Server.lean
+++ b/src/Lean/Server/Server.lean
@@ -84,6 +84,14 @@ match openDocuments.find? key with
 def updateOpenDocuments (s : ServerState) (key : DocumentUri) (val : Document) : IO Unit :=
 s.openDocumentsRef.modify (fun documents => (documents.erase key).insert key val)
 
+-- Clears diagnostics for the document version 'd'.
+-- TODO how to clear all diagnostics? Sending version 'none' doesn't seem to work
+def clearDiagnostics (s : ServerState) (uri : DocumentUri) (d : Document) : IO Unit :=
+writeLspNotification s.o "textDocument/publishDiagnostics"
+  { uri := uri
+  , version? := d.version
+  , diagnostics := #[] : PublishDiagnosticsParams }
+
 def sendDiagnostics (s : ServerState) (uri : DocumentUri) (d : Document) (log : MessageLog) : IO Unit :=
 let diagnostics := log.msgs.map (msgToDiagnostic d.text);
 writeLspNotification s.o "textDocument/publishDiagnostics"
@@ -100,10 +108,10 @@ s.openDocumentsRef.modify (fun openDocuments => openDocuments.insert doc.uri new
 s.sendDiagnostics doc.uri newDoc msgLog
 
 def handleDidChange (s : ServerState) (p : DidChangeTextDocumentParams) : IO Unit := do
-let doc := p.textDocument;
+let docId := p.textDocument;
 let changes := p.contentChanges;
-oldDoc ← s.findOpenDocument doc.uri;
-some newVersion ← pure doc.version? | throw (userError "expected version number");
+oldDoc ← s.findOpenDocument docId.uri;
+some newVersion ← pure docId.version? | throw (userError "expected version number");
 if newVersion <= oldDoc.version then do
   throw (userError "got outdated version number")
 else changes.forM $ fun change =>
@@ -112,8 +120,12 @@ else changes.forM $ fun change =>
     let newDocText := replaceRange oldDoc.text range newText;
     (newEnv, msgLog) ← updateFrontend oldDoc.headerEnv ("\n".intercalate newDocText.toList);
     let newDoc : Document := ⟨newVersion, newDocText, oldDoc.headerEnv⟩;
-    s.updateOpenDocuments doc.uri newDoc;
-    s.sendDiagnostics doc.uri newDoc msgLog
+    s.updateOpenDocuments docId.uri newDoc;
+    -- Clients don't have to clear diagnostics, so we clear them
+    -- for the *previous* version here.
+    s.clearDiagnostics docId.uri oldDoc;
+    s.sendDiagnostics docId.uri newDoc msgLog
+
   | TextDocumentContentChangeEvent.fullChange (text : String) =>
     throw (userError "got content change that replaces the full document (not supported)")
 
@@ -149,7 +161,7 @@ def initialize (i o : FS.Handle) : IO Unit := do
 r ← readLspRequestAs i "initialize" InitializeParams;
 writeLspResponse o r.id ({ capabilities := mkLeanServerCapabilities
                          , serverInfo? := some { name := "Lean 4 server"
-                                                , version? := "0.0.1" }} : InitializeResult);
+                                               , version? := "0.0.1" }} : InitializeResult);
 _ ← readLspRequestNotificationAs i "initialized" Initialized;
 openDocumentsRef ← IO.mkRef (RBMap.empty : DocumentMap);
 ServerState.mainLoop ⟨i, o, openDocumentsRef⟩


### PR DESCRIPTION
Diagnostics! Most of these changes are just me reading through the code and copy-pasting comments from the LSP spec. The salient changes are:
- make the empty environment using `mkEmptyEnvironment` which also sets up the extension state. Otherwise Lean just hangs
- remove French quotes on serializing `Range`
- wrap the initialization response in `InitializeResult`
- clear old diagnostics
- fix `insertAll`

With this VSCode displays the server's diagnostics, ~~although on wrong lines for now~~.